### PR TITLE
Extend label_list to include test_labels

### DIFF
--- a/topmost/preprocessing/preprocessing.py
+++ b/topmost/preprocessing/preprocessing.py
@@ -238,7 +238,7 @@ class Preprocessing:
 
     def convert_labels(self, train_labels, test_labels):
         if train_labels is not None:
-            label_list = list(set(train_labels))
+            label_list = list(set(train_labels).union(set(test_labels)))
             label_list.sort()
             n_labels = len(label_list)
             label2id = dict(zip(label_list, range(n_labels)))


### PR DESCRIPTION
In the current implementation, the `label_list` does not include the `test_labels` provided by the user, which results in an error during execution. This update addresses the issue by ensuring that `test_labels` are added to the `label_list`, thereby preventing errors and improving the code's robustness.